### PR TITLE
Add support for draft-6 examples

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ function convertSchema(schema, path, parent, parentPath) {
 	schema = rewriteConst(schema);
 	schema = convertDependencies(schema);
 	schema = rewriteIfThenElse(schema);
-	schema = rewriteExclusiveMinMax(schema);
+  schema = rewriteExclusiveMinMax(schema);
+  schema = convertExamples(schema);
 
 	if (typeof schema['patternProperties'] === 'object') {
 		schema = convertPatternProperties(schema);
@@ -148,6 +149,15 @@ function convertPatternProperties(schema) {
 	return schema;
 }
 
+function convertExamples(schema) {
+  if (schema['examples']) {
+    schema['example'] = schema['examples'][0];
+    delete schema['examples'];
+  }
+
+  return schema;
+}
+
 function rewriteConst(schema) {
 	if (schema.const) {
 		schema.enum = [ schema.const ];
@@ -191,4 +201,3 @@ function rewriteExclusiveMinMax(schema) {
 }
 
 module.exports = convert;
-

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ function convertPatternProperties(schema) {
 }
 
 function convertExamples(schema) {
-  if (schema['examples']) {
+  if (schema['examples'] && Array.isArray(schema['examples'])) {
     schema['example'] = schema['examples'][0];
     delete schema['examples'];
   }

--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ function convertSchema(schema, path, parent, parentPath) {
 	schema = rewriteConst(schema);
 	schema = convertDependencies(schema);
 	schema = rewriteIfThenElse(schema);
-  schema = rewriteExclusiveMinMax(schema);
-  schema = convertExamples(schema);
+        schema = rewriteExclusiveMinMax(schema);
+        schema = convertExamples(schema);
 
 	if (typeof schema['patternProperties'] === 'object') {
 		schema = convertPatternProperties(schema);

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const convert = require('../');
+const should = require('should');
+
+it('uses the first example from a schema', () => {
+  const schema = {
+    $schema: 'http://json-schema.org/draft-06/schema#',
+    examples: [
+      'foo',
+      'bar'
+    ]
+  };
+
+  const result = convert(schema);
+
+  should(result).deepEqual({
+    example: 'foo',
+  });
+});


### PR DESCRIPTION
## Description
This adds support for draft-6 examples. Since OpenAPI only supports single examples this transform takes the first example from the array of examples and sets that as the value. I've been using my implementation with speccy for a few days and its been working great and is a must have for my workflow.

Resolves #20 